### PR TITLE
[fix][troy] - orders admin staff assignment required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17466,16 +17466,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/components/orderAdmin.js
+++ b/src/components/orderAdmin.js
@@ -151,6 +151,17 @@ function OrderAdmin() {
 
   // Handle status change with modal confirmation for Complete and Cancel
   const handleStatusChange = async (order, newStatus) => {
+    // Check if staff is assigned before allowing completion or cancellation
+    if (
+      (newStatus === "Completed" || newStatus === "Cancelled") &&
+      order.assignTo === "Unassigned"
+    ) {
+      setNotification(
+        "You must assign staff before completing or canceling an order."
+      );
+      return;
+    }
+
     if (newStatus === "Completed" || newStatus === "Cancelled") {
       setModalData({ order, newStatus }); // Set modal data and open modal
       setShowModal(true);


### PR DESCRIPTION
user will have to assign first a staff before completing or canceling an order